### PR TITLE
Update flash-attn install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ If your device supports fp16 or bf16, we recommend installing [flash-attention](
 
 ```bash
 git clone https://github.com/Dao-AILab/flash-attention
-cd flash-attention && pip install .
+cd flash-attention && pip install packaging ninja flash-attn --no-build-isolation.
 # Below are optional. Installing them might be slow.
 # pip install csrc/layer_norm
 # If the version of flash-attn is higher than 2.1.1, the following is not needed.


### PR DESCRIPTION
match the install instructions to the repo; resolves build issues such as:

```
Building wheels for collected packages: flash-attn                                                                                                
  Building wheel for flash-attn (setup.py) ... error                                                                                              
  error: subprocess-exited-with-error                                                                                                             
                                                                                                                                                  
  × python setup.py bdist_wheel did not run successfully.                                                                                         
  │ exit code: 1                                                                                                                                  
  ╰─> [9 lines of output]                                                                                                                         
                                                                                                                                                  
                                                                                                                                                  
      torch.__version__  = 2.1.2                                                                                                                  
                                                                                                                                                  
                                                                                                                                                        running bdist_wheel                                                                                                                         
      Guessing wheel URL:  https://github.com/Dao-AILab/flash-attention/releases/download/v2.3.6/flash_attn-2.3.6+cu122torch2.1cxx11abiFALSE-cp311
-cp311-linux_x86_64.whl                                                                                                                           
      Raw wheel path /tmp/pip-wheel-u9phaxns/flash_attn-2.3.6-cp311-cp311-linux_x86_64.whl                                                        
      error: [Errno 18] Invalid cross-device link: 'flash_attn-2.3.6+cu122torch2.1cxx11abiFALSE-cp311-cp311-linux_x86_64.whl' -> '/tmp/pip-wheel-u9phaxns/flash_attn-2.3.6-cp311-cp311-linux_x86_64.whl'                                                                                            
      [end of output]                                                                                                                             
                                                                                                                                                  
  note: This error originates from a subprocess, and is likely not a problem with pip.                                                            
  ERROR: Failed building wheel for flash-attn                                                                                                     
  Running setup.py clean for flash-attn                                                                                                           
Failed to build flash-attn                                                                                                                        
ERROR: Could not build wheels for flash-attn, which is required to install pyproject.toml-based projects  
```