### PR TITLE
PythonAstREPLTool has been removed from langchain

### DIFF
--- a/examples/langchain_tooluse.ipynb
+++ b/examples/langchain_tooluse.ipynb
@@ -34,7 +34,7 @@
     "!pip install -r requirements.txt\n",
     "\n",
     "# 安装 langchain 相关依赖\n",
-    "!pip install langchain google-search-results wolframalpha arxiv;"
+    "!pip install langchain google-search-results wolframalpha arxiv langchain_experimental;"
    ]
   },
   {
@@ -73,7 +73,7 @@
     "from langchain import SerpAPIWrapper\n",
     "from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper\n",
     "from langchain.utilities import ArxivAPIWrapper\n",
-    "from langchain.tools.python.tool import PythonAstREPLTool\n",
+    "from langchain_experimental.tools.python.tool import PythonAstREPLTool\n",
     "\n",
     "from typing import Dict, Tuple\n",
     "import os\n",


### PR DESCRIPTION
langchain has removed the PythonAstREPLTool from langchain  and add it to langchain_experimental due to security reason