### PR TITLE
fix: replace 5 bare except clauses with except Exception

### DIFF
--- a/dcu-support/package/fastllm_pytools/llm.py
+++ b/dcu-support/package/fastllm_pytools/llm.py
@@ -272,7 +272,7 @@ class model:
             try:
                 cur = ret.decode();
                 ret = b'';
-            except:
+            except Exception:
                 fail_cnt += 1;
                 if (fail_cnt == 20):
                     break;

--- a/eval/evaluate_gsm8k.py
+++ b/eval/evaluate_gsm8k.py
@@ -61,7 +61,7 @@ def extract_answer(completion):
     try:
         last_number = re.findall(r"\d+", completion)[-1]
         return eval(last_number)
-    except:
+    except Exception:
         return INVALID_ANS
 
 

--- a/eval/evaluate_plugin.py
+++ b/eval/evaluate_plugin.py
@@ -44,7 +44,7 @@ def process_res(response):
         action_input = json.dumps(
             json5.loads(action_input), ensure_ascii=False, sort_keys=True
         )
-    except:
+    except Exception:
         # print("JSON Load Error:", action_input)
         action_input = ""
     res_dict = {


### PR DESCRIPTION
## What
Replace 5 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.